### PR TITLE
Fix optional paramaters in listStores()

### DIFF
--- a/src/Endpoints/Stores.php
+++ b/src/Endpoints/Stores.php
@@ -39,7 +39,14 @@ class Stores extends BaseEndpoint
      */
     public function listStores($showInactive = false, $marketplaceId = '')
     {
-        return $this->get('', ['query' => compact('showInactive', 'marketplaceId')]);
+        $params = array();
+        if($showInactive != false)
+            $params['showInactive'] = $showInactive;
+        }
+        if($marketplaceId != ''){
+            $params['marketplaceId'] = $marketplaceId;
+        }
+        return $this->get('', ['query' => $params]);
     }
 
     /**

--- a/src/Endpoints/Stores.php
+++ b/src/Endpoints/Stores.php
@@ -40,7 +40,7 @@ class Stores extends BaseEndpoint
     public function listStores($showInactive = false, $marketplaceId = '')
     {
         $params = array();
-        if($showInactive != false)
+        if($showInactive != false){
             $params['showInactive'] = $showInactive;
         }
         if($marketplaceId != ''){


### PR DESCRIPTION
The ShipStation API specifies that all listStores() parameters are optional.

https://www.shipstation.com/developer-api/#/reference/stores/list-stores/list-stores